### PR TITLE
Enable cross-compiling Windows DLLs from Linux

### DIFF
--- a/base/SConstruct
+++ b/base/SConstruct
@@ -23,7 +23,7 @@ elif sys.platform == "darwin":
 elif sys.platform == "win32" or sys.platform == "msys":
     host_platform = "windows"
 else:
-    raise ValueError("Could not detect platform automatically, please specify with " "platform=<platform>")
+    raise ValueError("Could not detect platform automatically, please specify with platform=<platform>")
 
 env = Environment(ENV=os.environ)
 
@@ -34,7 +34,7 @@ opts.Add(EnumVariable("target", "Compilation target", "debug", allowed_values=("
 opts.Add(
     EnumVariable(
         "platform",
-        "Compilation platform",
+        "Target platform",
         host_platform,
         # We'll need to support these in due times
         # allowed_values=("linux", "freebsd", "osx", "windows", "android", "ios", "javascript"),
@@ -66,6 +66,14 @@ if host_platform == "windows" and env["platform"] != "android":
         env = Environment(TARGET_ARCH="x86")
 
     opts.Update(env)
+
+# Require C++17
+if host_platform == "windows" and env["platform"] == "windows" and not env["use_mingw"]:
+    # MSVC
+    env.Append(CXXFLAGS=["/std:c++17"])
+else:
+    env.Append(CXXFLAGS=["-std=c++17"])
+    
 
 # Process some arguments
 if env["use_llvm"]:
@@ -113,7 +121,6 @@ if env["platform"] == "osx":
 elif env["platform"] in ("x11", "linux"):
     cpp_library += ".linux"
     env.Append(CCFLAGS=["-fPIC"])
-    env.Append(CXXFLAGS=["-std=c++17"])
     if env["target"] == "debug":
         env.Append(CCFLAGS=["-g3", "-Og"])
     else:
@@ -122,23 +129,67 @@ elif env["platform"] in ("x11", "linux"):
     arch_suffix = str(bits)
 elif env["platform"] == "windows":
     cpp_library += ".windows"
-    # This makes sure to keep the session environment variables on windows,
-    # that way you can run scons in a vs 2017 prompt and it will find all the required tools
-    env.Append(ENV=os.environ)
 
-    env.Append(CPPDEFINES=["WIN32", "_WIN32", "_WINDOWS", "_CRT_SECURE_NO_WARNINGS"])
-    env.Append(CCFLAGS=["-W3", "-GR"])
-    env.Append(CXXFLAGS=["-std:c++17"])
-    if env["target"] == "debug":
-        env.Append(CPPDEFINES=["_DEBUG"])
-        env.Append(CCFLAGS=["-EHsc", "-MDd", "-ZI", "-FS"])
-        env.Append(LINKFLAGS=["-DEBUG"])
-    else:
-        env.Append(CPPDEFINES=["NDEBUG"])
-        env.Append(CCFLAGS=["-O2", "-EHsc", "-MD"])
+    if host_platform == "windows" and not env["use_mingw"]:
+        # MSVC
+        # This makes sure to keep the session environment variables on windows,
+        # that way you can run scons in a vs 2017 prompt and it will find all the required tools
+        env.Append(ENV=os.environ)
 
-    if not(env["use_llvm"]):
-        env.Append(CPPDEFINES=["TYPED_METHOD_BIND"])
+        env.Append(CPPDEFINES=["WIN32", "_WIN32", "_WINDOWS", "_CRT_SECURE_NO_WARNINGS"])
+        env.Append(CCFLAGS=["-W3", "-GR"])
+        env.Append(CXXFLAGS=["-std:c++17"])
+        if env["target"] == "debug":
+            env.Append(CPPDEFINES=["_DEBUG"])
+            env.Append(CCFLAGS=["-EHsc", "-MDd", "-ZI", "-FS"])
+            env.Append(LINKFLAGS=["-DEBUG"])
+        else:
+            env.Append(CPPDEFINES=["NDEBUG"])
+            env.Append(CCFLAGS=["-O2", "-EHsc", "-MD"])
+
+        if not(env["use_llvm"]):
+            env.Append(CPPDEFINES=["TYPED_METHOD_BIND"])
+	    
+    elif host_platform == "linux" or host_platform == "freebsd" or host_platform == "osx":
+        # Cross-compilation using MinGW
+        if env["bits"] == "64":
+            env["CXX"] = "x86_64-w64-mingw32-g++"
+            env["AR"] = "x86_64-w64-mingw32-ar"
+            env["RANLIB"] = "x86_64-w64-mingw32-ranlib"
+            env["LINK"] = "x86_64-w64-mingw32-g++"
+        elif env["bits"] == "32":
+            env["CXX"] = "i686-w64-mingw32-g++"
+            env["AR"] = "i686-w64-mingw32-ar"
+            env["RANLIB"] = "i686-w64-mingw32-ranlib"
+            env["LINK"] = "i686-w64-mingw32-g++"
+
+    elif host_platform == "windows" and env["use_mingw"]:
+        # Don't Clone the environment. Because otherwise, SCons will pick up msvc stuff.
+        env = Environment(ENV=os.environ, tools=["mingw"])
+        opts.Update(env)
+
+        # Still need to use C++17.
+        env.Append(CCFLAGS=["-std=c++17"])
+        # Don't want lib prefixes
+        env["IMPLIBPREFIX"] = ""
+        env["SHLIBPREFIX"] = ""
+
+        # Long line hack. Use custom spawn, quick AR append (to avoid files with the same names to override each other).
+        env["SPAWN"] = mySpawn
+        env.Replace(ARFLAGS=["q"])
+
+    # Native or cross-compilation using MinGW
+    if host_platform == "linux" or host_platform == "freebsd" or host_platform == "osx" or env["use_mingw"]:
+        # These options are for a release build even using target=debug
+        env.Append(CCFLAGS=["-O3", "-Wwrite-strings"])
+        env.Append(
+            LINKFLAGS=[
+                "--static",
+                "-Wl,--no-undefined",
+                "-static-libgcc",
+                "-static-libstdc++",
+            ]
+        )
 
     arch_suffix = str(bits)
 

--- a/base/SConstruct
+++ b/base/SConstruct
@@ -162,6 +162,10 @@ elif env["platform"] == "windows":
             env["AR"] = "i686-w64-mingw32-ar"
             env["RANLIB"] = "i686-w64-mingw32-ranlib"
             env["LINK"] = "i686-w64-mingw32-g++"
+        # DLLs seem to be given a .so file extension even though they are DLLs unless
+        # you specify the extension
+        env["SHLIBSUFFIX"] = ".dll"
+
 
     elif host_platform == "windows" and env["use_mingw"]:
         # Don't Clone the environment. Because otherwise, SCons will pick up msvc stuff.


### PR DESCRIPTION
Fixes #3 - getting the following
```
g++: error: unrecognized command line option ‘-std:c++17’; did you mean ‘-std=c++17’?
g++: error: unrecognized command line option ‘-W3’; did you mean ‘-W’?
g++: error: unrecognized command line option ‘-GR’; did you mean ‘-R’?
g++: error: unrecognized command line option ‘-EHsc’
g++: error: unrecognized command line option ‘-MDd’; did you mean ‘-MD’?
g++: error: unrecognized command line option ‘-ZI’; did you mean ‘-I’?
```
errors when targetting windows platform from linux platform.

Moves some code from https://github.com/godotengine/godot-cpp/blob/master/SConstruct into base/SConstruct, as SConstruct in this project appears to be a cut down version of the godot-cpp one, and targeting Windows from Linux is working in godot-cpp

(Also adds `env["SHLIBSUFFIX"] = ".dll"`, which godot-cpp didn't need because it wasn't producing DLLs)